### PR TITLE
Create run-parachute script

### DIFF
--- a/roswell/run-parachute.ros
+++ b/roswell/run-parachute.ros
@@ -42,26 +42,28 @@ Options
 (defun main (&rest argv)
   (when (< (length argv) 1)
     (show-help))
-  (loop with reporter = "plain"
-        for args = argv then (rest args)
-        while args
-        for arg = (first args)
-        if (or (string= "--help" arg) (string= "-h" arg))
-        do (show-help) ; calls uiop:quit
-        else if (or (string= "--quickload" arg) (string= "-l" arg))
-        collect (second args) into loaded-systems
-        and do (setf args (rest args))
-        else if (or (string= "--exclude" arg) (string= "-e" arg))
-        collect (second args) into excluded
-        and do (setf args (rest args))
-        else if (or (string= "--report" arg) (string= "-r" arg))
-        do (setf reporter (second args)
-                 args (cdr args))
-        else
-        collect arg into tests
-        finally (ci-utils/coveralls:with-coveralls (append excluded (ci-utils/coveralls:coverage-excluded))
-                  (when loaded-systems
-                    (ql:quickload loaded-systems))
-                  (parachute:test-toplevel (mapcar 'read-from-string tests)
-                                           :report (let ((*package* (find-package "PARACHUTE")))
-                                                     (read-from-string reporter))))))
+  (let ((loaded-systems ())
+        (excluded (ci-utils/coveralls:coverage-excluded))
+        (reporter "plain"))
+    (loop for args = argv then (rest args)
+          for arg = (first args)
+          while args
+          do (cond ((or (string= "--help" arg) (string= "-h" arg))
+                    (show-help)) ; calls uiop:quit
+                   ((or (string= "--help" arg) (string= "-h" arg))
+                    (push (second args) loaded-systems)
+                    (setf args (rest args)))
+                   ((or (string= "--exclude" arg) (string= "-e" arg))
+                    (push (second args) excluded)
+                    (setf args (rest args)))
+                   ((or (string= "--report" arg) (string= "-r" arg))
+                    (setf reporter (second args)
+                          args (rest args)))
+                   (T
+                    (push arg tests))))
+    (ci-utils/coveralls:with-coveralls excluded
+      (when loaded-systems
+        (ql:quickload loaded-systems))
+      (parachute:test-toplevel (mapcar 'read-from-string (reverse tests))
+                               :report (let ((*package* (find-package "PARACHUTE")))
+                                         (read-from-string reporter))))))

--- a/roswell/run-parachute.ros
+++ b/roswell/run-parachute.ros
@@ -1,0 +1,61 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+
+;cmucl crashes with silent on
+(ql:quickload '(:ci-utils :ci-utils/coveralls :parachute :iterate)
+              :silent (not (member :cmu *features*)))
+
+(defpackage :ros.script.run-parachute
+  (:use :cl
+        :iterate))
+(in-package :ros.script.run-parachute)
+
+
+(defun show-help ()
+  (format t "~
+Usage: run-parachute [options] <test names>...
+Loads the system with quicklisp then calls parachute:test with a list of the
+test names.  Each test name is parsed with read-from-string after all systems
+are loaded, so package qualified names can be used.
+
+If the COVERALLS environemenal variable is present and non-empty, coverage will
+be measured and reported to COVERALLS on platforms supported by CI-Utils.
+Additionally, the environmental variable COVERAGE_EXCLUDED is read as a colon
+seperated list of paths to exclude from measuring coverage, in addition to those
+specified as arguments.
+
+Note that currently the systems in the project root are loaded with
+COVERALLS is  enable.  This behavior is not to be relied on and may change in
+the future, so instead use the `--quicklisp`/`-l` flag.
+Options
+--help|-h                     - prints this help message
+--quickload|-l <sytem>        - loads the specified system via quicklisp
+--coverage-exclude|-e <file>  - excludes the path from any coverage measurements
+                                measurement~%")
+  (uiop:quit 2))
+
+
+(defun main (&rest argv)
+  (when (> 1 (length argv))
+    (show-help))
+  (iter (generate arg-list in argv)
+        (for arg = (next arg-list))
+    (cond
+      ((or (string= "--help" arg) (string= "-h" arg))
+       (show-help))
+      ((or (string= "--quickload" arg) (string= "-l" arg))
+       (collect (next arg-list) into loaded-systems))
+      ((or (string= "--exclude" arg) (string= "-e" arg))
+       (collect (next arg-list) into excluded))
+      (t
+       (collect arg into tests)))
+    ;evaluate tests here with `loaded-systems`, `excluded`, and `tests` in scope
+    (finally
+      (setf excluded (nconc excluded (ci-utils/coveralls:coverage-excluded)))
+      (ci-utils/coveralls:with-coveralls excluded
+        (when loaded-systems
+          (ql:quickload loaded-systems))
+        (parachute:test-toplevel (mapcar 'read-from-string tests))))))

--- a/roswell/run-parachute.ros
+++ b/roswell/run-parachute.ros
@@ -44,11 +44,12 @@ Options
     (show-help))
   (loop with reporter = "plain"
         for args = argv then (rest args)
+        while args
         for arg = (first args)
         if (or (string= "--help" arg) (string= "-h" arg))
         do (show-help) ; calls uiop:quit
         else if (or (string= "--quickload" arg) (string= "-l" arg))
-        collect (second args) into loaded-system
+        collect (second args) into loaded-systems
         and do (setf args (rest args))
         else if (or (string= "--exclude" arg) (string= "-e" arg))
         collect (second args) into excluded
@@ -58,11 +59,9 @@ Options
                  args (cdr args))
         else
         collect arg into tests
-        finally (progn
-                  (setf excluded (append excluded (ci-utils/coveralls:coverage-excluded)))
-                  (ci-utils/coveralls:with-coveralls excluded
-                    (when loaded-systems
-                      (ql:quickload loaded-systems))
-                    (parachute:test-toplevel (mapcar 'read-from-string tests)
-                                             :report (let ((*package* (find-package "PARACHUTE")))
-                                                       (read-from-string reporter)))))))
+        finally (ci-utils/coveralls:with-coveralls (append excluded (ci-utils/coveralls:coverage-excluded))
+                  (when loaded-systems
+                    (ql:quickload loaded-systems))
+                  (parachute:test-toplevel (mapcar 'read-from-string tests)
+                                           :report (let ((*package* (find-package "PARACHUTE")))
+                                                     (read-from-string reporter))))))

--- a/roswell/run-parachute.ros
+++ b/roswell/run-parachute.ros
@@ -5,7 +5,7 @@ exec ros -Q -- $0 "$@"
 |#
 
 ;cmucl crashes with silent on
-(ql:quickload '(:ci-utils :ci-utils/coveralls :parachute :iterate)
+(ql:quickload '(:ci-utils/coveralls :parachute)
               :silent (not (member :cmu *features*)))
 
 (defpackage :ros.script.run-parachute
@@ -41,21 +41,20 @@ Options
 (defun main (&rest argv)
   (when (> 1 (length argv))
     (show-help))
-  (iter (generate arg-list in argv)
-        (for arg = (next arg-list))
-    (cond
-      ((or (string= "--help" arg) (string= "-h" arg))
-       (show-help))
-      ((or (string= "--quickload" arg) (string= "-l" arg))
-       (collect (next arg-list) into loaded-systems))
-      ((or (string= "--exclude" arg) (string= "-e" arg))
-       (collect (next arg-list) into excluded))
-      (t
-       (collect arg into tests)))
-    ;evaluate tests here with `loaded-systems`, `excluded`, and `tests` in scope
-    (finally
-      (setf excluded (nconc excluded (ci-utils/coveralls:coverage-excluded)))
-      (ci-utils/coveralls:with-coveralls excluded
-        (when loaded-systems
-          (ql:quickload loaded-systems))
-        (parachute:test-toplevel (mapcar 'read-from-string tests))))))
+  (loop for args = argv then (rest args)
+        for arg = (first args)
+        if (or (string= "--help" arg) (string= "-h" arg))
+        do (show-help) ; calls uiop:quit
+        else if (or (string= "--quickload" arg) (string= "-l" arg))
+        collect (second args) into loaded-system
+        and do (setf args (rest args))
+        else if (or (string= "--exclude" arg) (string= "-e" arg))
+        collect (second args) into excluded
+        and do (setf args (rest args))
+        else
+        collect arg into tests
+        finally (progn
+                  (setf excluded (nconc excluded (ci-utils/coveralls:coverage-excluded)))
+                  (when loaded-systems
+                    (ql:quickload loaded-systems))
+                  (parachute:test-toplevel (mapcar 'read-from-string tests)))))

--- a/roswell/run-parachute.ros
+++ b/roswell/run-parachute.ros
@@ -32,14 +32,18 @@ Options
 --help|-h                     - prints this help message
 --quickload|-l <sytem>        - loads the specified system via quicklisp
 --coverage-exclude|-e <file>  - excludes the path from any coverage measurements
-                                measurement~%")
+                                measurement
+--report|-r <reporter>        - Uses the specified parachute reporter class.
+                                The value is read from the parachute package
+                                after all user specified systems are loaded.~%")
   (uiop:quit 2))
 
 
 (defun main (&rest argv)
   (when (< (length argv) 1)
     (show-help))
-  (loop for args = argv then (rest args)
+  (loop with reporter = "plain"
+        for args = argv then (rest args)
         for arg = (first args)
         if (or (string= "--help" arg) (string= "-h" arg))
         do (show-help) ; calls uiop:quit
@@ -49,10 +53,16 @@ Options
         else if (or (string= "--exclude" arg) (string= "-e" arg))
         collect (second args) into excluded
         and do (setf args (rest args))
+        else if (or (string= "--report" arg) (string= "-r" arg))
+        do (setf reporter (second args)
+                 args (cdr args))
         else
         collect arg into tests
         finally (progn
                   (setf excluded (append excluded (ci-utils/coveralls:coverage-excluded)))
-                  (when loaded-systems
-                    (ql:quickload loaded-systems))
-                  (parachute:test-toplevel (mapcar 'read-from-string tests)))))
+                  (ci-utils/coveralls:with-coveralls excluded
+                    (when loaded-systems
+                      (ql:quickload loaded-systems))
+                    (parachute:test-toplevel (mapcar 'read-from-string tests)
+                                             :report (let ((*package* (find-package "PARACHUTE")))
+                                                       (read-from-string reporter)))))))

--- a/roswell/run-parachute.ros
+++ b/roswell/run-parachute.ros
@@ -4,18 +4,16 @@
 exec ros -Q -- $0 "$@"
 |#
 
-;cmucl crashes with silent on
 (ql:quickload '(:ci-utils/coveralls :parachute)
-              :silent (not (member :cmu *features*)))
+              :silent (not (member :cmu *features*))) ; cmucl crashes with silent on
 
-(defpackage :ros.script.run-parachute
-  (:use :cl
-        :iterate))
-(in-package :ros.script.run-parachute)
+(defpackage #:ros.script.run-parachute
+  (:use #:cl))
+(in-package #:ros.script.run-parachute)
 
 
 (defun show-help ()
-  (format t "~
+  (format T "~
 Usage: run-parachute [options] <test names>...
 Loads the system with quicklisp then calls parachute:test with a list of the
 test names.  Each test name is parsed with read-from-string after all systems
@@ -39,7 +37,7 @@ Options
 
 
 (defun main (&rest argv)
-  (when (> 1 (length argv))
+  (when (< (length argv) 1)
     (show-help))
   (loop for args = argv then (rest args)
         for arg = (first args)
@@ -54,7 +52,7 @@ Options
         else
         collect arg into tests
         finally (progn
-                  (setf excluded (nconc excluded (ci-utils/coveralls:coverage-excluded)))
+                  (setf excluded (append excluded (ci-utils/coveralls:coverage-excluded)))
                   (when loaded-systems
                     (ql:quickload loaded-systems))
                   (parachute:test-toplevel (mapcar 'read-from-string tests)))))


### PR DESCRIPTION
Similar to run-fiveam and run-prove, the script is designed to make it easy to run parachute tests on CI platforms (in fact, it's run-fiveam with fiveam replaced with parachute).

If the script is installed by Roswell, the `foo-test` package in the `foo/test` system can be tested with
`run-parachute-l foo/test-parachute foo-tests-parachute` (or `roswell/run-parachute.ros -e t -l foo/test-parachute foo-tests-parachute` if measuring coverage and excluding the `t` directory from coverage)

Example of tests passing: https://travis-ci.org/neil-lindquist/cl-ci-test/builds/579901976
Example of tests failing: https://travis-ci.org/neil-lindquist/cl-ci-test/builds/579896736
