### PR TITLE
Add a summary report class

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -172,6 +172,14 @@ See SUMMARIZE")
 See REPORT
 See RESULT")
 
+    (type summary
+    "A plain-text report that prints only a summary at the end.
+
+See PLAIN
+See REPORT
+See OUTPUT
+See REPORT-ON")
+
   (type interactive
     "An interactive test report that shows the debugger on every failure, with restarts that allow you to decide what to do next.
 

--- a/package.lisp
+++ b/package.lisp
@@ -28,6 +28,7 @@
    #:summarize
    #:quiet
    #:plain
+   #:summary
    #:output
    #:report-on
    #:interactive)

--- a/parachute.asd
+++ b/parachute.asd
@@ -6,7 +6,7 @@
 
 
 (asdf:defsystem parachute
-  :version "1.4.0"
+  :version "1.5.0"
   :license "zlib"
   :author "Nicolas Hafner <shinmera@tymoon.eu>"
   :maintainer "Nicolas Hafner <shinmera@tymoon.eu>"

--- a/report.lisp
+++ b/report.lisp
@@ -75,6 +75,10 @@
   (:default-initargs :stream *standard-output*
                      :show-listing T))
 
+(defclass summary (plain)
+  ()
+  (:default-initargs :show-listing nil))
+
 (defvar *level* 0)
 
 (defmethod eval-in-context :before ((report plain) (result parent-result))


### PR DESCRIPTION
As discussed in #34.

This is just a subclass of the `plain` class called `summary`, which suppresses the progress reports via a different default initarg.  As such its summary is the same as `plain`'s summary.

It might be better in some sense to make both `plain` and `summary` be subclasses of some common 'plain text' report class which then differ only in their default initargs, but I think that might be overengineering.

Note that I have *not* recreated the HTML documentation: I have added an entry for `summary` to `documentation.lisp` but I don't understand the documentation utilities well enough to know how to recreate the HTML.  So that, at least needs doing.

I've bumped the minor version number: not sure if that's right.

I've tested this in my own small test suites, but not in more than one implementation and not in anything big.