### PR TITLE
Handle *print-circle* to stop the thing exploding

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -66,6 +66,10 @@
                 ((eql 'function (first thing))
                  (format output "#'")
                  (print-oneline (second thing) output))
+                (*print-circle*
+                 ;; Anything is better than dying.  Anything.
+                 (let ((*print-lines* 1))
+                   (princ thing output)))
                 (T
                  (format output "(")
                  (loop for (car . cdr) on thing


### PR DESCRIPTION
This is not a perfect fix for #38, but it does at least stop the Lisp from blowing up when test reports include circular structure.