### PR TITLE
Add *status-indicators* plist

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -937,4 +937,5 @@ have the status values of :passed, :failed, :skipped, :tentative and
 :unknown.")
 
   (function status-character
-    "Return the appropriate status indicator for a specific result status."))
+    "Return the appropriate status indicator for a specific result status. See
+*STATUS-INDICATORS*."))

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -931,7 +931,7 @@ that are unresolvable.")
   (function call-compile
     "Compiles the form with muffled warnings and calls the resulting function.")
 
-  (variable *status-characters*
+  (variable *status-indicators*
     "A plist which maps status values to a strings used in reports. Should
 have the status values of :passed, :failed, :skipped, :tentative and
 :unknown.")

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -936,5 +936,5 @@ that are unresolvable.")
 have the status values of :passed, :failed, :skipped, :tentative and
 :unknown.")
 
-  (function status-characters
+  (function status-character
     "Return the appropriate status indicator for a specific result status."))

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -929,4 +929,12 @@ this will error if the quasiquote contains any form of lexical references
 that are unresolvable.")
 
   (function call-compile
-    "Compiles the form with muffled warnings and calls the resulting function."))
+    "Compiles the form with muffled warnings and calls the resulting function.")
+
+  (variable *status-characters*
+    "A plist which maps status values to a strings used in reports. Should
+have the status values of :passed, :failed, :skipped, :tentative and
+:unknown.")
+
+  (function status-characters
+    "Return the appropriate status indicator for a specific result status."))

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -937,5 +937,6 @@ have the status values of :passed, :failed, :skipped, :tentative and
 :unknown.")
 
   (function status-character
-    "Return the appropriate status indicator for a specific result status. See
-*STATUS-INDICATORS*."))
+    "Return the appropriate status indicator for a specific result status.
+
+See *STATUS-INDICATORS*"))

--- a/package.lisp
+++ b/package.lisp
@@ -111,5 +111,5 @@
   (:export
    #:featurep
    #:with-shuffling
-   #:*status-characters*
+   #:*status-indicators*
    #:status-character))

--- a/package.lisp
+++ b/package.lisp
@@ -111,4 +111,5 @@
   (:export
    #:featurep
    #:with-shuffling
+   #:*status-characters*
    #:status-character))

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -164,9 +164,12 @@
     (bail (&rest args)
       (values-list args))))
 
+(defvar *status-characters*
+  '(:passed    #+asdf-unicode "✔" #-asdf-unicode "o"
+    :failed    #+asdf-unicode "✘" #-asdf-unicode "x"
+    :skipped   #+asdf-unicode "ー" #-asdf-unicode "-"
+    :tentative #+asdf-unicode "？" #-asdf-unicode "?"
+    :unknown   #+asdf-unicode "？" #-asdf-unicode "?"))
+
 (defun status-character (status)
-  (case status
-    (:passed  #+asdf-unicode "✔" #-asdf-unicode "o")
-    (:failed  #+asdf-unicode "✘" #-asdf-unicode "x")
-    (:skipped #+asdf-unicode "ー" #-asdf-unicode "-")
-    (T        #+asdf-unicode "？" #-asdf-unicode "?")))
+  (getf *status-characters* status "?"))

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -164,7 +164,7 @@
     (bail (&rest args)
       (values-list args))))
 
-(defvar *status-characters*
+(defvar *status-indicators*
   '(:passed    #+asdf-unicode "✔" #-asdf-unicode "o"
     :failed    #+asdf-unicode "✘" #-asdf-unicode "x"
     :skipped   #+asdf-unicode "ー" #-asdf-unicode "-"
@@ -172,4 +172,4 @@
     :unknown   #+asdf-unicode "？" #-asdf-unicode "?"))
 
 (defun status-character (status)
-  (getf *status-characters* status "?"))
+  (getf *status-indicators* status "?"))


### PR DESCRIPTION
Adds `*status-characters*` plist so that the various status indicators can be customized. This is useful when the terminal (or browser for CI) font doesn't support the default indicators.