### PR TITLE
WIP/proof of concept: add source location to tests and test-results

### DIFF
--- a/parachute.asd
+++ b/parachute.asd
@@ -18,6 +18,7 @@
                (:file "documentation"))
   :depends-on (:documentation-utils
                :trivial-custom-debugger
+               :trivial-source-location
                :form-fiddle))
 
 (asdf:defsystem parachute/example

--- a/result.lisp
+++ b/result.lisp
@@ -8,18 +8,22 @@
     (call-next-method)))
 
 (defmethod result-for-testable ((test test) context)
-  (make-instance 'test-result :expression test))
+  (make-instance 'test-result
+                 :expression test
+                 :source-location (source-location test)))
 
 (defclass result ()
   ((expression :initarg :expression :accessor expression)
    (status :initarg :status :accessor status)
    (duration :initarg :duration :accessor duration)
-   (description :initarg :description :accessor description))
+   (description :initarg :description :accessor description)
+   (source-location :initarg :source-location :accessor source-location))
   (:default-initargs
    :expression (error "EXPRESSION required.")
    :status :unknown
    :duration NIL
-   :description NIL))
+   :description NIL
+   :source-location NIL))
 
 (defmethod initialize-instance :after ((result result) &key)
   (when *parent* (add-result result *parent*))
@@ -52,7 +56,7 @@
                  (timeout ()))
             (setf (duration result) (/ (- (get-internal-real-time) start)
                                        internal-time-units-per-second))))
-      ;; Mark ourselves as passed if we didn't already set the status.    
+      ;; Mark ourselves as passed if we didn't already set the status.
       (unless (result-complete-p result)
         (setf (status result) :passed)))))
 

--- a/test.lisp
+++ b/test.lisp
@@ -16,7 +16,8 @@
    (time-limit :initarg :time-limit :accessor time-limit)
    (skipped-children :initarg :skip :initarg :skipped-children :accessor referenced-skips)
    (tests :initarg :tests :accessor tests)
-   (serial :initarg :serial :accessor serial))
+   (serial :initarg :serial :accessor serial)
+   (source-location :initarg :source-location :accessor source-location))
   (:default-initargs
    :name (error "NAME required.")
    :home *package*
@@ -27,7 +28,8 @@
    :time-limit NIL
    :skipped-children NIL
    :serial T
-   :tests ()))
+   :tests ()
+   :source-location NIL))
 
 (defmethod shared-initialize :after ((test test) slots &key parent home name)
   (declare (ignore slots))
@@ -159,7 +161,8 @@
                                                              (:execute `(lambda () (call-compile ',form))))))
                               :parent ',(or parent nparent)
                               ,@(loop for option in options
-                                      collect `',option)))
+                                      collect `',option)
+                              :source-location ',(trivial-source-location:current-source-location)))
            ,@(loop for (def subname . body) in defs
                    collect `(,def (,name ,subname)
                               :home ,home

--- a/tester.lisp
+++ b/tester.lisp
@@ -10,7 +10,8 @@
                    :expected 'T
                    :comparison 'geq
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro false (form &optional description &rest format-args)
   `(eval-in-context
@@ -22,7 +23,8 @@
                    :expected 'NIL
                    :comparison 'geq
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro is (comp expected form &optional description &rest format-args)
   `(eval-in-context
@@ -34,7 +36,8 @@
                    :expected ,expected
                    :comparison ,(maybe-quote comp)
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro isnt (comp expected form &optional description &rest format-args)
   `(eval-in-context
@@ -75,7 +78,8 @@
                      :expected (list ,@expected)
                      :comparison (list ,@comparison)
                      ,@(when description
-                         `(:description (format NIL ,description ,@format-args)))))))
+                         `(:description (format NIL ,description ,@format-args)))
+                     :source-location ',(trivial-source-location:current-source-location)))))
 
 (defmacro isnt-values (form &body body)
   (multiple-value-bind (comp-expected expected comparison description format-args)
@@ -90,7 +94,8 @@
                      :comparison (list ,@comparison)
                      :comparison-geq NIL
                      ,@(when description
-                         `(:description (format NIL ,description ,@format-args)))))))
+                         `(:description (format NIL ,description ,@format-args)))
+                     :source-location ',(trivial-source-location:current-source-location)))))
 
 (defmacro fail (form &optional (type 'error) description &rest format-args)
   `(eval-in-context
@@ -102,7 +107,8 @@
                    :expected ',(maybe-unquote type)
                    :comparison 'typep
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro fail-compile (form &optional (type 'error) description &rest format-args)
   `(eval-in-context
@@ -114,7 +120,8 @@
                    :expected ',(maybe-unquote type)
                    :comparison 'typep
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro of-type (type form &optional description &rest format-args)
   `(eval-in-context
@@ -126,7 +133,8 @@
                    :expected ',(maybe-unquote type)
                    :comparison 'typep
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro finish (form &optional description &rest format-args)
   `(eval-in-context
@@ -135,7 +143,8 @@
                    :expression '(finish ,form)
                    :body (lambda () ,form)
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro with-forced-status ((status &optional description &rest format-args) &body tests)
   `(eval-in-context
@@ -145,7 +154,8 @@
                    :child-status ,status
                    :body (lambda () ,@tests)
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))
 
 (defmacro skip (desc &body tests)
   `(with-forced-status (:skipped ,@(if (listp desc) desc (list desc)))
@@ -167,4 +177,5 @@
                    :expression ',name
                    :body (lambda () ,@tests)
                    ,@(when description
-                       `(:description (format NIL ,description ,@format-args))))))
+                       `(:description (format NIL ,description ,@format-args)))
+                   :source-location ',(trivial-source-location:current-source-location))))


### PR DESCRIPTION
I just wanted to have your opinion on these kind of changes before I try anything else.

---

- this add a slot `source-location` to the classes `test` and `test-result`
- it is populated if the system [trivial-source-location](https://codeberg.org/fstamour/trivial-source-location) (which I'm working on a the same time) is loaded 